### PR TITLE
documentation fix of args to arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ cd rt-kernel-docker-builder
 ```
 
 ```bash
-$ docker build [--build-args UNAME_R=<raspi release>] [--build-args RT_PATCH=<RT patch>] -t rtwg-image .
+$ docker build [--build-arg UNAME_R=<raspi release>] [--build-arg RT_PATCH=<RT patch>] -t rtwg-image .
 ```
 
 where:


### PR DESCRIPTION
Example in README doesn't run, changed to valid docker build flag.