### PR TITLE
Instruction to ensure performance governor is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ $ cd $HOME
 $ sudo dpkg -i *.deb
 ```
 
+## Disable ondemand.service to enable the performance governor.
+
+Ubuntu has an ondemand.service that forces the cpu governor to ondemand post boot. This can be disabled via:
+
+```bash
+$ sudo systemctl disable ondemand
+```
+
+After fixing the /boot symlinks and rebooting, you can check the governor:
+
+```bash
+$ cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+performance
+performance
+performance
+performance
+```
+
 ## Adjust ```vmlinuz``` and ```initrd.img``` links
 
 There is an extra step in compare to the x86_64 install because ```update-initramfs``` ignores new kernel
@@ -169,6 +187,10 @@ After reboot you should see a new RT kernel installed
 ubuntu@ubuntu:~$ uname -a
 Linux ubuntu 5.4.101-rt53 #1 SMP PREEMPT_RT Mon May 17 12:10:16 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
 ```
+
+### Disable the ondemand.service to enable the performance cpu governor
+
+
 
 ## Intel UP2 board RT kernel build
 


### PR DESCRIPTION
Ubuntu has an `ondemand.service` that sets the cpu governor to ondemand post boot. This needs to be disabled via `systemctl disable ondemand`.

```
ubuntu@ubuntu:/etc/default$ uname -a
Linux ubuntu 5.4.128-rt61 #1 SMP PREEMPT_RT Sat Sep 4 15:19:34 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
ubuntu@ubuntu:/etc/default$ cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
ondemand
ondemand
ondemand
ondemand
ubuntu@ubuntu:/etc/default$ sudo systemctl status ondemand
● ondemand.service - Set the CPU Frequency Scaling governor
     Loaded: loaded (/lib/systemd/system/ondemand.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Sat 2021-09-04 15:46:10 UTC; 2min 17s ago
    Process: 1680 ExecStart=/lib/systemd/set-cpufreq (code=exited, status=0/SUCCESS)
   Main PID: 1680 (code=exited, status=0/SUCCESS)

Sep 04 15:46:05 ubuntu systemd[1]: Started Set the CPU Frequency Scaling governor.
Sep 04 15:46:10 ubuntu set-cpufreq[1680]: Setting ondemand scheduler for all CPUs
Sep 04 15:46:10 ubuntu systemd[1]: ondemand.service: Succeeded.
ubuntu@ubuntu:/etc/default$ 
```